### PR TITLE
fix refresh token

### DIFF
--- a/src/AuthBundle/Entity/RefreshToken.php
+++ b/src/AuthBundle/Entity/RefreshToken.php
@@ -18,13 +18,13 @@ class RefreshToken extends BaseRefreshToken
     protected $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Client", cascade={"persist", "remove"})
+     * @ORM\ManyToOne(targetEntity="Client", cascade={"persist"})
      * @ORM\JoinColumn(name="client_id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $client;
 
     /**
-     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\User", cascade={"persist", "remove"})
+     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\User", cascade={"persist"})
      * @ORM\JoinColumn(name="user_id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $user;


### PR DESCRIPTION
now on deletion old refresh token related user and client are deleted too, we need to drop "remove" from cascade option to avoid it